### PR TITLE
Deploy 2bc05f40

### DIFF
--- a/group_vars/restbase-production
+++ b/group_vars/restbase-production
@@ -1,7 +1,7 @@
 # This is where we parametrize the restbase role for the 'restbase' cluster
 #restbase_version: origin/master
 cluster: restbase
-restbase_version: 3006b77e
+restbase_version: 2bc05f40
 
 seeds:
     - restbase1001.eqiad.wmnet


### PR DESCRIPTION
This is a small deploy that brings in sending `no-cache` headers for MobileApps routes (to be deployed before https://gerrit.wikimedia.org/r/#/c/247935/ which sets up the back-end handlers appropriately)