### PR TITLE
AQS: check port 7232 instead of 7231

### DIFF
--- a/group_vars/aqs-production
+++ b/group_vars/aqs-production
@@ -5,6 +5,8 @@ cluster: restbase
 restbase_version: origin/master
 #restbase_version: 
 
+restbase_port: 7232
+
 restbase_repository: https://gerrit.wikimedia.org/r/mediawiki/services/aqs/deploy
 
 seeds:

--- a/roles/restbase/tasks/check.yml
+++ b/roles/restbase/tasks/check.yml
@@ -1,2 +1,2 @@
 - name: check port 7231
-  wait_for: host={{ inventory_hostname }} port=7231 state=started timeout=180
+  wait_for: host={{ inventory_hostname }} port={{ restbase_port|default(7231)  }} state=started timeout=180


### PR DESCRIPTION
AQS' port has recently been changed to 7232 due to the LVS conflict with the main RESTBase cluster. Consequently, when deploying we should check that port for AQS instead of the default 7231.