### PR TITLE
instances-aware Cassandra restart

### DIFF
--- a/roles/cassandra/tasks/restart.yml
+++ b/roles/cassandra/tasks/restart.yml
@@ -1,5 +1,14 @@
+
+# Legacy (one instance per host): Do restart when `instance` is not defined.
 - name: restart cassandra
   service: name=cassandra state=restarted
+  when: instance is undefined
+
+# Multi-instance restart: When `instance` is defined, append it to create the
+# derived (instance-specific) service name.
+- name: restart cassandra (instance-based)
+  service: name=cassandra{{ '-' ~ instance | default('') }} state=restarted
+  when: instance is defined
 
 - include: check.yml
 

--- a/staging
+++ b/staging
@@ -17,9 +17,12 @@ praseodymium.eqiad.wmnet
 cerium.eqiad.wmnet
 
 [restbase-staging-codfw]
-restbase-test2001.codfw.wmnet
-restbase-test2002.codfw.wmnet
-restbase-test2003.codfw.wmnet
+restbase-test2001-a.codfw.wmnet instance=a
+restbase-test2001-b.codfw.wmnet instance=b
+restbase-test2002-a.codfw.wmnet instance=a
+restbase-test2002-b.codfw.wmnet instance=b
+restbase-test2003-a.codfw.wmnet instance=a
+restbase-test2003-b.codfw.wmnet instance=b
 
 # By DC
 [codfw:children]


### PR DESCRIPTION
Adds support of rolling Cassandra restarts on hosts that have multiple
Cassandra instances running.  Each such instance is specified using the
instance-specific hostname, and had an `instance` host variable indicating
the instance id.

This is a little janky.  The way it is implemented, you will see output
for two different forms of restart, one for the legacy method, and another
that is instance-based.  Depending on the node type, one will be skipped
and the other ran.

Bug: https://phabricator.wikimedia.org/T117114