### PR TITLE
Skip the 10s LVS wait delay

### DIFF
--- a/roles/restbase/tasks/restart.yml
+++ b/roles/restbase/tasks/restart.yml
@@ -3,5 +3,5 @@
 
 - include: check.yml
 
-- name: wait 10s for LVS
-  wait_for: timeout=10
+#- name: wait 10s for LVS
+#  wait_for: timeout=10


### PR DESCRIPTION
Our clusters are large enough to not need this any more. We could consider
conditionally re-adding this for small clusters later.