### PR TITLE
Pool and depool nodes properly during restarts

### DIFF
--- a/group_vars/restbase-labs
+++ b/group_vars/restbase-labs
@@ -21,3 +21,4 @@ salt_key: secretkey
 restbase_config_template: config.labs.yaml.j2
 
 use_service_checker: false
+pool_restbase: false

--- a/group_vars/restbase-production
+++ b/group_vars/restbase-production
@@ -24,3 +24,4 @@ salt_key:
 restbase_config_template: config.yaml.j2
 
 use_service_checker: true
+pool_restbase: true

--- a/group_vars/restbase-staging
+++ b/group_vars/restbase-staging
@@ -23,3 +23,4 @@ salt_key:
 restbase_config_template: config.yaml.j2
 
 use_service_checker: true
+pool_restbase: false

--- a/roles/restbase/tasks/restart.yml
+++ b/roles/restbase/tasks/restart.yml
@@ -1,7 +1,6 @@
 - name: depool restbase
-  # TODO: supply the pool name to depool from, for now it
-  # works like this because restbase is the only pyball service
-  command: depool
+  command: depool-restbase
+  when: pool_restbase
 
 - name: restart restbase
   service: name=restbase state=restarted
@@ -9,6 +8,5 @@
 - include: check.yml
 
 - name: repool back restbase
-  # TODO: supply the pool name to repool to, for now it
-  # works like this because restbase is the only pyball service
-  command: pool
+  command: pool-restbase
+  when: pool_restbase


### PR DESCRIPTION
There are now robust scripts that pool/depool servers from LVS in a
reliable manner. Use those instead of the generic `pool` and `depool`
ones used thus far. Also, do depooling and repooling only for production
nodes because labs do not have these new scripts, and staging is not
behind LVS anyway.